### PR TITLE
[fix] 위경도 거꾸로 넣은 에러 수정 (핀 안찍힌 에러 해결)

### DIFF
--- a/NearByApp/NearByApp/Model/LocationInfoModel.swift
+++ b/NearByApp/NearByApp/Model/LocationInfoModel.swift
@@ -28,8 +28,8 @@ struct LocationInfoModel {
     }
     
     func docToMapPoint(_ doc : DetailLocData) -> MTMapPoint {
-        let latitude = Double(doc.x) ?? .zero
-        let longitude = Double(doc.y) ?? .zero
+        let longitude = Double(doc.x) ?? .zero
+        let latitude = Double(doc.y) ?? .zero
         return MTMapPoint(geoCoord: MTMapPointGeo(latitude: latitude, longitude: longitude))
     }
     


### PR DESCRIPTION
- 위도와 경도를 반대로 맵핑 했다....
- 그래서 핀이 안찍혔었다...
- 영어공부를 하자
- 위도(lat)는 가로선(y)이고, 경도(lon)는 세로선(x) ... 꼭 기억하자
